### PR TITLE
Fix missing PyQt import

### DIFF
--- a/pde_solver/gui.py
+++ b/pde_solver/gui.py
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout, QLabel, QSlider, QPushButton, QDoubleSpinBox, QComboBox, QFileDialog, QSpinBox
 )
 from PyQt5.QtCore import Qt, QTimer, QPointF
-from PyQt5.QtGui import QPainter, QColor
+from PyQt5.QtGui import QPainter, QColor, QLinearGradient
 from OpenGL.GL import *
 from OpenGL.GLU import *
 from scipy.sparse import diags, identity, kron, csc_matrix


### PR DESCRIPTION
## Summary
- import `QLinearGradient` to avoid NameError in ColorScaleWidget

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f7251b4483288d470d7dc09a486f